### PR TITLE
Respect allowed shifts in schedule algorithm

### DIFF
--- a/src/lib/shiftScheduler.ts
+++ b/src/lib/shiftScheduler.ts
@@ -139,6 +139,7 @@ export class ShiftScheduler {
             return this.employeeWorkloads[a.id].hours - this.employeeWorkloads[b.id].hours;
           });
           for (const employee of sorted) {
+            if (!employee.allowedShifts.includes(shiftType.id)) continue;
             if (!this.isEmployeeAvailable(employee, currentDate, shiftType)) continue;
 
             const alreadyAssigned = this.assignments.some(a => a.employeeId === employee.id && a.date === dateStr);


### PR DESCRIPTION
## Summary
- check employee.allowedShifts before assigning shifts in the scheduler

## Testing
- `bun x biome lint --write` *(fails: numerous existing lint errors)*
- `bun x tsc --noEmit` *(fails: multiple type errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f557d1ef48320a65fa354315e5aa0