### PR TITLE
Fix handling of zero shift percentage overrides

### DIFF
--- a/src/components/EmployeeManagement.tsx
+++ b/src/components/EmployeeManagement.tsx
@@ -423,11 +423,16 @@ export function EmployeeManagement() {
                     type="number"
                     min="0"
                     max="100"
-                    value={formData.specificShiftPercentage || ''}
-                    onChange={(e) => setFormData(prev => ({
-                      ...prev,
-                      specificShiftPercentage: e.target.value ? Number(e.target.value) : undefined
-                    }))}
+                    value={formData.specificShiftPercentage ?? ''}
+                    onChange={(e) =>
+                      setFormData(prev => ({
+                        ...prev,
+                        specificShiftPercentage:
+                          e.target.value === ''
+                            ? undefined
+                            : Number(e.target.value),
+                      }))
+                    }
                     placeholder="Leer = Team-Standard"
                   />
                 </div>

--- a/src/lib/csvUtils.ts
+++ b/src/lib/csvUtils.ts
@@ -77,7 +77,7 @@ export function employeesToCSV(employees: Employee[]): string {
       employee.lehrjahr || "",
       employee.grade,
       employee.teamId,
-      employee.specificShiftPercentage || "",
+      employee.specificShiftPercentage ?? "",
       JSON.stringify(employee.allowedShifts),
       JSON.stringify(employee.availability),
       employee.createdAt.toISOString(),


### PR DESCRIPTION
## Summary
- export specific shift percentage correctly in CSV
- allow zero for individual shift percentage field

## Testing
- `npm run lint` *(fails: bunx not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe0efa4008320911d46228d0b8009