### PR TITLE
Implement hourly workload display

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## ShiftPlanner Notes
+
+This project includes a shift scheduling system. The scheduler tracks the
+workload of each employee in **hours** based on assigned shift durations. These
+hourly workloads are used throughout the analytics dashboard and reports.

--- a/src/components/AnalyticsDashboard.tsx
+++ b/src/components/AnalyticsDashboard.tsx
@@ -37,7 +37,11 @@ export function AnalyticsDashboard({
 
   // Calculate total working hours in the period
   const calculateTotalHours = () => {
-    return Object.values(workloadStats).reduce((total, stats) => total + stats.hours, 0);
+    const total = Object.values(workloadStats).reduce(
+      (sum, stats) => sum + stats.hours,
+      0,
+    );
+    return Number(total.toFixed(1));
   };
 
   // Calculate shift coverage statistics


### PR DESCRIPTION
## Summary
- show total hours rounded to one decimal in AnalyticsDashboard
- mention hourly workload tracking in README

## Testing
- `npm run lint` *(fails: bunx not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe60273e88320820ba6653181a283