### PR TITLE
Fix team editing with missing leader

### DIFF
--- a/src/components/TeamManagement.tsx
+++ b/src/components/TeamManagement.tsx
@@ -70,7 +70,9 @@ export function TeamManagement() {
       setFormData({
         name: team.name,
         overallShiftPercentage: team.overallShiftPercentage,
-        teamLeaderId: team.teamLeaderId,
+        teamLeaderId: employees.some((e) => e.id === team.teamLeaderId)
+          ? team.teamLeaderId
+          : undefined,
       });
     } else {
       resetForm();


### PR DESCRIPTION
## Summary
- avoid invalid value if team leader was removed when editing teams

## Testing
- `npm run lint` *(fails: bunx not found)*
- `npm run format` *(fails: bunx not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fed29ca808320a7b56d638fd1c5cd