### PR TITLE
Improve scheduler and absences

### DIFF
--- a/src/components/AbsenceCalendar.tsx
+++ b/src/components/AbsenceCalendar.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import type { Employee, Absence } from '@/lib/types';
+
+interface AbsenceCalendarProps {
+  employees: Employee[];
+  absences: Absence[];
+}
+
+export function AbsenceCalendar({ employees, absences }: AbsenceCalendarProps) {
+  const [currentMonth, setCurrentMonth] = useState(() => {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), 1);
+  });
+
+  const daysInMonth = new Date(
+    currentMonth.getFullYear(),
+    currentMonth.getMonth() + 1,
+    0,
+  ).getDate();
+
+  const daysArray = Array.from({ length: daysInMonth }, (_, i) =>
+    new Date(currentMonth.getFullYear(), currentMonth.getMonth(), i + 1),
+  );
+
+  const prevMonth = () =>
+    setCurrentMonth(
+      new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1),
+    );
+  const nextMonth = () =>
+    setCurrentMonth(
+      new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1),
+    );
+
+  const isAbsent = (
+    employeeId: string,
+    date: string,
+  ): Absence | undefined => {
+    return absences.find(
+      (a) =>
+        a.employeeId === employeeId &&
+        date >= a.startDate &&
+        date <= a.endDate,
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Button variant="outline" size="sm" onClick={prevMonth}>
+          Zurück
+        </Button>
+        <div className="font-medium">
+          {currentMonth.toLocaleDateString('de-DE', {
+            month: 'long',
+            year: 'numeric',
+          })}
+        </div>
+        <Button variant="outline" size="sm" onClick={nextMonth}>
+          Weiter
+        </Button>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr>
+              <th className="border p-2 bg-gray-50 text-left font-medium min-w-[120px]">
+                Mitarbeiter
+              </th>
+              {daysArray.map((d) => (
+                <th
+                  key={d.toISOString()}
+                  className="border p-1 bg-gray-50 text-center text-xs"
+                >
+                  {d.getDate()}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {employees.map((emp) => (
+              <tr key={emp.id}>
+                <td className="border p-1 bg-gray-50 text-sm font-medium">
+                  {emp.firstName} {emp.lastName}
+                </td>
+                {daysArray.map((d) => {
+                  const dateStr = d.toISOString().split('T')[0];
+                  const absence = isAbsent(emp.id, dateStr);
+                  return (
+                    <td
+                      key={dateStr}
+                      className={`border p-1 text-center text-xs ${absence ? 'bg-red-100' : ''}`}
+                      title={absence?.reason || ''}
+                    >
+                      {absence ? 'X' : ''}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AbsenceManagement.tsx
+++ b/src/components/AbsenceManagement.tsx
@@ -7,12 +7,14 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card } from '@/components/ui/card';
 import { Plus, Edit } from 'lucide-react';
 import { useData } from './DataProvider';
 import { useToast } from '@/hooks/use-toast';
 import { saveAbsence, updateAbsence, deleteAbsence } from '@/lib/dataManager';
 import type { Absence } from '@/lib/types';
+import { AbsenceCalendar } from './AbsenceCalendar';
 
 interface AbsenceFormData {
   employeeId: string;
@@ -145,40 +147,55 @@ export function AbsenceManagement() {
           </DialogContent>
         </Dialog>
       </div>
-      <div className="border rounded-lg">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Mitarbeiter</TableHead>
-              <TableHead>Von</TableHead>
-              <TableHead>Bis</TableHead>
-              <TableHead>Grund</TableHead>
-              <TableHead className="text-right">Aktionen</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {absences.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center py-4 text-gray-500">Keine Abwesenheiten erfasst.</TableCell>
-              </TableRow>
-            ) : (
-              absences.map(a => (
-                <TableRow key={a.id}>
-                  <TableCell className="font-medium">{getEmployeeName(a.employeeId)}</TableCell>
-                  <TableCell>{a.startDate}</TableCell>
-                  <TableCell>{a.endDate}</TableCell>
-                  <TableCell>{a.reason}</TableCell>
-                  <TableCell className="text-right">
-                    <Button variant="ghost" size="sm" onClick={() => handleOpenDialog(a)}>
-                      <Edit className="w-4 h-4" />
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
+      <Tabs defaultValue="calendar" className="space-y-4">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="calendar">Kalender</TabsTrigger>
+          <TabsTrigger value="list">Liste</TabsTrigger>
+        </TabsList>
+        <TabsContent value="calendar">
+          <Card>
+            <AbsenceCalendar employees={employees} absences={absences} />
+          </Card>
+        </TabsContent>
+        <TabsContent value="list">
+          <Card>
+            <div className="border rounded-lg">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Mitarbeiter</TableHead>
+                    <TableHead>Von</TableHead>
+                    <TableHead>Bis</TableHead>
+                    <TableHead>Grund</TableHead>
+                    <TableHead className="text-right">Aktionen</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {absences.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={5} className="text-center py-4 text-gray-500">Keine Abwesenheiten erfasst.</TableCell>
+                    </TableRow>
+                  ) : (
+                    absences.map(a => (
+                      <TableRow key={a.id}>
+                        <TableCell className="font-medium">{getEmployeeName(a.employeeId)}</TableCell>
+                        <TableCell>{a.startDate}</TableCell>
+                        <TableCell>{a.endDate}</TableCell>
+                        <TableCell>{a.reason}</TableCell>
+                        <TableCell className="text-right">
+                          <Button variant="ghost" size="sm" onClick={() => handleOpenDialog(a)}>
+                            <Edit className="w-4 h-4" />
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </Card>
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/src/lib/shiftScheduler.ts
+++ b/src/lib/shiftScheduler.ts
@@ -228,6 +228,11 @@ export class ShiftScheduler {
       if (weekday) {
         const dateStr = currentDate.toISOString().split('T')[0];
         for (const shiftType of this.options.shiftTypes) {
+          // Skip if a primary assignment already exists for this slot
+          if (this.assignments.some(a => a.date === dateStr && a.shiftId === shiftType.id && !a.isFollowUp)) {
+            continue;
+          }
+
           let assigned = false;
           if (this.firstVmShiftId && this.zeroShiftId && shiftType.id === this.firstVmShiftId) {
             const zeroAssign = this.assignments.find(a => a.date === dateStr && a.shiftId === this.zeroShiftId && !a.isFollowUp);


### PR DESCRIPTION
## Summary
- add absence calendar with monthly navigation
- show calendar alongside existing table
- prevent duplicate assignments in scheduler

## Testing
- `npm run lint` *(fails: The number of diagnostics exceeds the number allowed by Biome)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683ff0f7db348320a2d4c03313597018