### PR TITLE
Fix select components using non-empty item values

### DIFF
--- a/src/components/ShiftCalendarGrid.tsx
+++ b/src/components/ShiftCalendarGrid.tsx
@@ -330,12 +330,17 @@ export function ShiftCalendarGrid({
             <div className="space-y-4">
               <div>
                 <label className="text-sm font-medium">Mitarbeiter auswählen</label>
-                <Select value={selectedEmployeeId} onValueChange={setSelectedEmployeeId}>
+                <Select
+                  value={selectedEmployeeId || "none"}
+                  onValueChange={(value) =>
+                    setSelectedEmployeeId(value === "none" ? "" : value)
+                  }
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="Mitarbeiter wählen oder leer lassen" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">Keine Zuweisung</SelectItem>
+                    <SelectItem value="none">Keine Zuweisung</SelectItem>
                     {getAvailableEmployees(editingCell.date, editingCell.shiftTypeId).map(employee => (
                       <SelectItem key={employee.id} value={employee.id}>
                         {employee.firstName} {employee.lastName} ({employee.kuerzel || 'Kein Kürzel'})

--- a/src/components/TeamManagement.tsx
+++ b/src/components/TeamManagement.tsx
@@ -299,11 +299,11 @@ export function TeamManagement() {
               <div>
                 <Label htmlFor="teamLeaderId">Teamleiter</Label>
                 <Select
-                  value={formData.teamLeaderId || ""}
+                  value={formData.teamLeaderId || "none"}
                   onValueChange={(value) =>
                     setFormData((prev) => ({
                       ...prev,
-                      teamLeaderId: value || undefined,
+                      teamLeaderId: value === "none" ? undefined : value,
                     }))
                   }
                 >
@@ -311,7 +311,7 @@ export function TeamManagement() {
                     <SelectValue placeholder="Mitarbeiter auswählen" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">Keiner</SelectItem>
+                    <SelectItem value="none">Keiner</SelectItem>
                     {employees.map((emp) => (
                       <SelectItem key={emp.id} value={emp.id}>
                         {emp.firstName} {emp.lastName}


### PR DESCRIPTION
## Summary
- update manual assignment dialog to use `value="none"` placeholder
- allow team leader selection to handle `"none"` value

## Testing
- `npm run lint` *(fails: bunx not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff508fb948320a7fb30ba6952acc5