### PR TITLE
Implement team-based shift quotas

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 This project includes a shift scheduling system. The scheduler tracks the
 workload of each employee in **hours** based on assigned shift durations. These
 hourly workloads are used throughout the analytics dashboard and reports.
+
+Teams can define an `overallShiftPercentage` to express what portion of all
+support shifts a team should cover. During scheduling, the algorithm prioritizes
+teams that are below their target share, distributing remaining shifts fairly
+between employees within each team.


### PR DESCRIPTION
## Summary
- extend shift scheduler statistics with team workloads
- compute team target shares and track workloads during initialization
- prioritize employees by how far their team is from the target share
- update README about overallShiftPercentage

## Testing
- `npm run lint` *(fails: bunx not found)*
- `npm run format` *(fails: bunx not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff8287d008320bf4b77c4585ff889