### PR TITLE
Add selectable absence calendar cells

### DIFF
--- a/src/components/AbsenceCalendar.tsx
+++ b/src/components/AbsenceCalendar.tsx
@@ -5,13 +5,16 @@ import type { Employee, Absence } from '@/lib/types';
 interface AbsenceCalendarProps {
   employees: Employee[];
   absences: Absence[];
+  onCellSelect?: (employeeId: string, date: string) => void;
 }
 
-export function AbsenceCalendar({ employees, absences }: AbsenceCalendarProps) {
+export function AbsenceCalendar({ employees, absences, onCellSelect }: AbsenceCalendarProps) {
   const [currentMonth, setCurrentMonth] = useState(() => {
     const now = new Date();
     return new Date(now.getFullYear(), now.getMonth(), 1);
   });
+
+  const [selectedCells, setSelectedCells] = useState<Set<string>>(new Set());
 
   const daysInMonth = new Date(
     currentMonth.getFullYear(),
@@ -31,6 +34,23 @@ export function AbsenceCalendar({ employees, absences }: AbsenceCalendarProps) {
     setCurrentMonth(
       new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1),
     );
+
+  const toggleCell = (employeeId: string, date: string) => {
+    const key = `${employeeId}-${date}`;
+    setSelectedCells((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(key)) {
+        newSet.delete(key);
+      } else {
+        newSet.add(key);
+      }
+      return newSet;
+    });
+
+    if (onCellSelect) {
+      onCellSelect(employeeId, date);
+    }
+  };
 
   const isAbsent = (
     employeeId: string,
@@ -70,7 +90,7 @@ export function AbsenceCalendar({ employees, absences }: AbsenceCalendarProps) {
               {daysArray.map((d) => (
                 <th
                   key={d.toISOString()}
-                  className="border p-1 bg-gray-50 text-center text-xs"
+                  className="border p-1 bg-gray-50 text-center text-xs min-w-[40px]"
                 >
                   {d.getDate()}
                 </th>
@@ -89,8 +109,15 @@ export function AbsenceCalendar({ employees, absences }: AbsenceCalendarProps) {
                   return (
                     <td
                       key={dateStr}
-                      className={`border p-1 text-center text-xs ${absence ? 'bg-red-100' : ''}`}
+                      className={`border p-1 text-center text-xs min-w-[40px] ${
+                        absence
+                          ? 'bg-red-100'
+                          : selectedCells.has(`${emp.id}-${dateStr}`)
+                            ? 'bg-blue-100'
+                            : ''
+                      }`}
                       title={absence?.reason || ''}
+                      onClick={() => toggleCell(emp.id, dateStr)}
                     >
                       {absence ? 'X' : ''}
                     </td>

--- a/src/components/AbsenceManagement.tsx
+++ b/src/components/AbsenceManagement.tsx
@@ -40,6 +40,12 @@ export function AbsenceManagement() {
     setEditingAbsence(null);
   };
 
+  const handleSelectFromCalendar = (employeeId: string, date: string) => {
+    setEditingAbsence(null);
+    setFormData({ employeeId, startDate: date, endDate: date, reason: '' });
+    setIsDialogOpen(true);
+  };
+
   const handleOpenDialog = (absence?: Absence) => {
     if (absence) {
       setEditingAbsence(absence);
@@ -154,7 +160,11 @@ export function AbsenceManagement() {
         </TabsList>
         <TabsContent value="calendar">
           <Card>
-            <AbsenceCalendar employees={employees} absences={absences} />
+            <AbsenceCalendar
+              employees={employees}
+              absences={absences}
+              onCellSelect={handleSelectFromCalendar}
+            />
           </Card>
         </TabsContent>
         <TabsContent value="list">


### PR DESCRIPTION
## Summary
- allow selecting days in `AbsenceCalendar`
- open absence dialog when a day is selected
- keep day columns a fixed width

## Testing
- `npx biome lint --write` *(fails: some existing project lint errors)*
- `npx tsc --noEmit` *(fails: existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_683ffb36970883208204995db9869874