### PR TITLE
Improve absence and manual scheduling handling

### DIFF
--- a/src/components/AbsenceManagement.tsx
+++ b/src/components/AbsenceManagement.tsx
@@ -40,9 +40,13 @@ export function AbsenceManagement() {
     setEditingAbsence(null);
   };
 
-  const handleSelectFromCalendar = (employeeId: string, date: string) => {
+  const handleSelectFromCalendar = (
+    employeeId: string,
+    start: string,
+    end: string,
+  ) => {
     setEditingAbsence(null);
-    setFormData({ employeeId, startDate: date, endDate: date, reason: '' });
+    setFormData({ employeeId, startDate: start, endDate: end, reason: '' });
     setIsDialogOpen(true);
   };
 
@@ -163,7 +167,7 @@ export function AbsenceManagement() {
             <AbsenceCalendar
               employees={employees}
               absences={absences}
-              onCellSelect={handleSelectFromCalendar}
+              onRangeSelect={handleSelectFromCalendar}
             />
           </Card>
         </TabsContent>

--- a/src/components/ShiftPlanner.tsx
+++ b/src/components/ShiftPlanner.tsx
@@ -465,6 +465,7 @@ export function ShiftPlanner() {
                   shiftTypes={shiftTypes}
                   assignments={currentAssignments}
                   conflicts={currentConflicts}
+                  absences={absences}
                   onAssignmentChange={handleAssignmentChange}
                 />
               </CardContent>

--- a/src/lib/shiftScheduler.ts
+++ b/src/lib/shiftScheduler.ts
@@ -256,8 +256,8 @@ export class ShiftScheduler {
       if (weekday) {
         const dateStr = currentDate.toISOString().split('T')[0];
         for (const shiftType of this.options.shiftTypes) {
-          // Skip if a primary assignment already exists for this slot
-          if (this.assignments.some(a => a.date === dateStr && a.shiftId === shiftType.id && !a.isFollowUp)) {
+          // Skip if any assignment already exists for this slot
+          if (this.assignments.some(a => a.date === dateStr && a.shiftId === shiftType.id)) {
             continue;
           }
 


### PR DESCRIPTION
## Summary
- allow selecting date ranges in the absence calendar
- open absence dialog with selected range
- validate availability when manually assigning shifts
- provide absences to shift calendar grid
- skip already assigned slots when scheduling to avoid duplicates

## Testing
- `bun x biome lint --write`
- `bun x tsc --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683ffebfc1588320ba88f57a315685d6