### PR TITLE
Implement rule management and absence editing

### DIFF
--- a/src/components/AbsenceCalendar.tsx
+++ b/src/components/AbsenceCalendar.tsx
@@ -6,9 +6,10 @@ interface AbsenceCalendarProps {
   employees: Employee[];
   absences: Absence[];
   onRangeSelect?: (employeeId: string, startDate: string, endDate: string) => void;
+  onAbsenceClick?: (absence: Absence) => void;
 }
 
-export function AbsenceCalendar({ employees, absences, onRangeSelect }: AbsenceCalendarProps) {
+export function AbsenceCalendar({ employees, absences, onRangeSelect, onAbsenceClick }: AbsenceCalendarProps) {
   const [currentMonth, setCurrentMonth] = useState(() => {
     const now = new Date();
     return new Date(now.getFullYear(), now.getMonth(), 1);
@@ -37,7 +38,24 @@ export function AbsenceCalendar({ employees, absences, onRangeSelect }: AbsenceC
       new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1),
     );
 
+  const isAbsent = (
+    employeeId: string,
+    date: string,
+  ): Absence | undefined => {
+    return absences.find(
+      (a) =>
+        a.employeeId === employeeId &&
+        date >= a.startDate &&
+        date <= a.endDate,
+    );
+  };
+
   const startDrag = (employeeId: string, date: string) => {
+    const absence = isAbsent(employeeId, date);
+    if (absence) {
+      onAbsenceClick?.(absence);
+      return;
+    }
     setDragStart({ empId: employeeId, date });
     setIsDragging(true);
     setSelectedCells(new Set([`${employeeId}-${date}`]));
@@ -77,18 +95,6 @@ export function AbsenceCalendar({ employees, absences, onRangeSelect }: AbsenceC
     if (onRangeSelect) {
       onRangeSelect(employeeId, startDate, endDate);
     }
-  };
-
-  const isAbsent = (
-    employeeId: string,
-    date: string,
-  ): Absence | undefined => {
-    return absences.find(
-      (a) =>
-        a.employeeId === employeeId &&
-        date >= a.startDate &&
-        date <= a.endDate,
-    );
   };
 
   return (

--- a/src/components/AbsenceManagement.tsx
+++ b/src/components/AbsenceManagement.tsx
@@ -50,6 +50,10 @@ export function AbsenceManagement() {
     setIsDialogOpen(true);
   };
 
+  const handleCalendarAbsenceClick = (absence: Absence) => {
+    handleOpenDialog(absence);
+  };
+
   const handleOpenDialog = (absence?: Absence) => {
     if (absence) {
       setEditingAbsence(absence);
@@ -168,6 +172,7 @@ export function AbsenceManagement() {
               employees={employees}
               absences={absences}
               onRangeSelect={handleSelectFromCalendar}
+              onAbsenceClick={handleCalendarAbsenceClick}
             />
           </Card>
         </TabsContent>

--- a/src/components/EmployeeManagement.tsx
+++ b/src/components/EmployeeManagement.tsx
@@ -31,10 +31,11 @@ interface EmployeeFormData {
   allowedShifts: string[];
   shiftSuitability: Record<string, number>;
   availability: Record<string, boolean>;
+  ruleIds: string[];
 }
 
 export function EmployeeManagement() {
-  const { employees, teams, shiftTypes, learningYearQualifications, refreshData } = useData();
+  const { employees, teams, shiftTypes, learningYearQualifications, shiftRules, refreshData } = useData();
   const { toast } = useToast();
   const { items: sortedEmployees, requestSort, sortConfig } = useSortableData(employees);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -50,6 +51,7 @@ export function EmployeeManagement() {
     allowedShifts: [],
     shiftSuitability: {},
     availability: createDefaultAvailability(),
+    ruleIds: [],
   });
 
   const resetForm = () => {
@@ -63,6 +65,7 @@ export function EmployeeManagement() {
       allowedShifts: [],
       shiftSuitability: {},
       availability: createDefaultAvailability(),
+      ruleIds: [],
     });
     setEditingEmployee(null);
   };
@@ -84,6 +87,7 @@ export function EmployeeManagement() {
         allowedShifts: employee.allowedShifts,
         shiftSuitability: employee.shiftSuitability || {},
         availability: employee.availability,
+        ruleIds: employee.ruleIds || [],
       });
     } else {
       resetForm();
@@ -177,6 +181,7 @@ export function EmployeeManagement() {
       allowedShifts: employee.allowedShifts,
       shiftSuitability: employee.shiftSuitability || {},
       availability: employee.availability,
+      ruleIds: employee.ruleIds || [],
     });
     setEditingEmployee(null);
     setIsDialogOpen(true);
@@ -511,6 +516,36 @@ export function EmployeeManagement() {
                   </Card>
                 </div>
               )}
+
+              <div>
+                <Label>Individuelle Regeln</Label>
+                <Card className="p-4 mt-2 max-h-40 overflow-y-auto">
+                  <div className="space-y-2">
+                    {shiftRules.map(rule => (
+                      <div key={rule.id} className="flex items-center space-x-2">
+                        <Checkbox
+                          id={`erule-${rule.id}`}
+                          checked={formData.ruleIds.includes(rule.id)}
+                          onCheckedChange={(checked) =>
+                            setFormData(prev => ({
+                              ...prev,
+                              ruleIds: checked
+                                ? [...prev.ruleIds, rule.id]
+                                : prev.ruleIds.filter(id => id !== rule.id),
+                            }))
+                          }
+                        />
+                        <Label htmlFor={`erule-${rule.id}`} className="text-sm">
+                          {rule.name || rule.type}
+                        </Label>
+                      </div>
+                    ))}
+                    {shiftRules.length === 0 && (
+                      <p className="text-sm text-gray-500">Keine Regeln definiert.</p>
+                    )}
+                  </div>
+                </Card>
+              </div>
 
               <div>
                 <Label>Verfügbarkeit</Label>

--- a/src/components/QualificationRuleModule.tsx
+++ b/src/components/QualificationRuleModule.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { LearningYearManagement } from './LearningYearManagement';
+import { ShiftRuleManagement } from './ShiftRuleManagement';
+
+export function QualificationRuleModule() {
+  return (
+    <Tabs defaultValue="learning" className="space-y-4">
+      <TabsList className="grid w-full grid-cols-2">
+        <TabsTrigger value="learning">Lehrjahre</TabsTrigger>
+        <TabsTrigger value="rules">Schichtregeln</TabsTrigger>
+      </TabsList>
+      <TabsContent value="learning">
+        <Card>
+          <CardHeader>
+            <CardTitle>Lehrjahr-Qualifikationen</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <LearningYearManagement />
+          </CardContent>
+        </Card>
+      </TabsContent>
+      <TabsContent value="rules">
+        <Card>
+          <CardHeader>
+            <CardTitle>Schichtregeln</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ShiftRuleManagement />
+          </CardContent>
+        </Card>
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/src/components/SchichtplanerApp.tsx
+++ b/src/components/SchichtplanerApp.tsx
@@ -7,8 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { EmployeeManagement } from './EmployeeManagement';
 import { TeamManagement } from './TeamManagement';
 import { ShiftTypeManagement } from './ShiftTypeManagement';
-import { LearningYearManagement } from './LearningYearManagement';
-import { ShiftRuleManagement } from './ShiftRuleManagement';
+import { QualificationRuleModule } from './QualificationRuleModule';
 import { AbsenceManagement } from './AbsenceManagement';
 import { ShiftPlanner } from './ShiftPlanner';
 import { DataProvider } from './DataProvider';
@@ -130,8 +129,7 @@ export function SchichtplanerApp() {
               <TabsTrigger value="employees">Mitarbeiter</TabsTrigger>
               <TabsTrigger value="teams">Teams</TabsTrigger>
               <TabsTrigger value="shift-types">Schichttypen</TabsTrigger>
-              <TabsTrigger value="learning-years">Lehrjahre</TabsTrigger>
-              <TabsTrigger value="shift-rules">Schichtregeln</TabsTrigger>
+              <TabsTrigger value="rules-module">Regeln</TabsTrigger>
               <TabsTrigger value="absences">Abwesenheiten</TabsTrigger>
               <TabsTrigger value="planner">Planer</TabsTrigger>
             </TabsList>
@@ -178,30 +176,10 @@ export function SchichtplanerApp() {
               </Card>
             </TabsContent>
 
-            <TabsContent value="learning-years">
+            <TabsContent value="rules-module">
               <Card>
-                <CardHeader>
-                  <CardTitle>Lehrjahr-Qualifikationen</CardTitle>
-                  <CardDescription>
-                    Konfigurieren Sie Qualifikationen und Verfügbarkeiten für verschiedene Lehrjahre.
-                  </CardDescription>
-                </CardHeader>
                 <CardContent>
-                  <LearningYearManagement />
-                </CardContent>
-              </Card>
-            </TabsContent>
-
-            <TabsContent value="shift-rules">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Schichtregeln</CardTitle>
-                  <CardDescription>
-                    Definieren Sie Regeln für Schichtfolgen und Arbeitsverteilungen.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <ShiftRuleManagement />
+                  <QualificationRuleModule />
                 </CardContent>
               </Card>
             </TabsContent>

--- a/src/components/ShiftRuleManagement.tsx
+++ b/src/components/ShiftRuleManagement.tsx
@@ -16,7 +16,7 @@ import type { ShiftRule } from '@/lib/types';
 import { useSortableData } from '@/hooks/useSortableData';
 
 interface ShiftRuleFormData {
-  type: 'forbidden_sequence' | 'mandatory_follow_up';
+  type: 'forbidden_sequence' | 'mandatory_follow_up' | string;
   fromShiftId: string;
   toShiftId?: string;
   toShiftIds?: string[];

--- a/src/components/TeamManagement.tsx
+++ b/src/components/TeamManagement.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/components/ui/dialog";
 import { Plus, Edit, Copy, Download, Upload } from "lucide-react";
 import { useData } from "./DataProvider";
+import { Checkbox } from "@/components/ui/checkbox";
 import { useToast } from "@/hooks/use-toast";
 import { saveTeam, updateTeam, deleteTeam } from "@/lib/dataManager";
 import { teamsToCSV, csvToTeams, downloadCSV } from "@/lib/csvUtils";
@@ -40,10 +41,11 @@ interface TeamFormData {
   name: string;
   overallShiftPercentage: number;
   teamLeaderId?: string;
+  ruleIds: string[];
 }
 
 export function TeamManagement() {
-  const { teams, employees, refreshData } = useData();
+  const { teams, employees, shiftRules, refreshData } = useData();
   const { toast } = useToast();
   const { items: sortedTeams, requestSort, sortConfig } = useSortableData(teams);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -53,6 +55,7 @@ export function TeamManagement() {
     name: "",
     overallShiftPercentage: 60,
     teamLeaderId: undefined,
+    ruleIds: [],
   });
 
   const resetForm = () => {
@@ -60,6 +63,7 @@ export function TeamManagement() {
       name: "",
       overallShiftPercentage: 60,
       teamLeaderId: undefined,
+      ruleIds: [],
     });
     setEditingTeam(null);
   };
@@ -73,6 +77,7 @@ export function TeamManagement() {
         teamLeaderId: employees.some((e) => e.id === team.teamLeaderId)
           ? team.teamLeaderId
           : undefined,
+        ruleIds: team.ruleIds || [],
       });
     } else {
       resetForm();
@@ -152,6 +157,8 @@ export function TeamManagement() {
     setFormData({
       name: `${team.name} (Kopie)`,
       overallShiftPercentage: team.overallShiftPercentage,
+      teamLeaderId: team.teamLeaderId,
+      ruleIds: team.ruleIds || [],
     });
     setEditingTeam(null);
     setIsDialogOpen(true);
@@ -319,6 +326,33 @@ export function TeamManagement() {
                     ))}
                   </SelectContent>
                 </Select>
+              </div>
+              <div>
+                <Label>Gültige Regeln</Label>
+                <div className="border p-2 rounded-md max-h-40 overflow-y-auto mt-2 space-y-1">
+                  {shiftRules.map(rule => (
+                    <div key={rule.id} className="flex items-center space-x-2">
+                      <Checkbox
+                        id={`rule-${rule.id}`}
+                        checked={formData.ruleIds.includes(rule.id)}
+                        onCheckedChange={(checked) =>
+                          setFormData(prev => ({
+                            ...prev,
+                            ruleIds: checked
+                              ? [...prev.ruleIds, rule.id]
+                              : prev.ruleIds.filter(id => id !== rule.id),
+                          }))
+                        }
+                      />
+                      <Label htmlFor={`rule-${rule.id}`} className="text-sm">
+                        {rule.name || rule.type}
+                      </Label>
+                    </div>
+                  ))}
+                  {shiftRules.length === 0 && (
+                    <p className="text-sm text-gray-500">Keine Regeln definiert.</p>
+                  )}
+                </div>
               </div>
 
               <DialogFooter>

--- a/src/lib/dataManager.ts
+++ b/src/lib/dataManager.ts
@@ -261,7 +261,12 @@ export function deleteShiftRule(id: string): boolean {
 
 // Shift plan management
 export function getShiftPlans(): ShiftPlan[] {
-  return getFromStorage<ShiftPlan>(STORAGE_KEYS.shiftPlans);
+  const stored = getFromStorage<ShiftPlan>(STORAGE_KEYS.shiftPlans);
+  return stored.map(p => ({
+    ...p,
+    startDate: new Date(p.startDate),
+    endDate: new Date(p.endDate),
+  }));
 }
 
 export function saveShiftPlan(shiftPlan: Omit<ShiftPlan, 'id' | 'createdAt' | 'updatedAt'>): ShiftPlan {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,8 @@ export interface Employee {
   teamId: string;
   specificShiftPercentage?: number; // Optional override for team percentage
   allowedShifts: string[]; // Array of shift type IDs
+  /** IDs of Schichtregeln, die speziell für diesen Mitarbeiter gelten */
+  ruleIds?: string[];
   /**
    * Optional rating of how suitable an employee is for a given shift type.
    * The key is the shift type id and the value is a number from 0-5 where 5
@@ -25,6 +27,8 @@ export interface Team {
   name: string;
   overallShiftPercentage: number; // Percentage (0-100)
   teamLeaderId?: string; // Optional employee ID of team leader
+  /** IDs of Schichtregeln, die für dieses Team gelten */
+  ruleIds?: string[];
   createdAt: Date;
   updatedAt: Date;
 }
@@ -48,6 +52,7 @@ export interface LearningYearQualification {
 }
 
 export interface ShiftRule {
+  id: string;
   type:
     | "forbidden_sequence"
     | "required_sequence"
@@ -60,6 +65,8 @@ export interface ShiftRule {
   name?: string;
   fromShiftName?: string; // für Logging/Anzeige
   toShiftName?: string; // für Logging/Anzeige
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface ShiftAssignment {


### PR DESCRIPTION
## Summary
- allow editing absences directly from the calendar
- add shift-rule selection for teams and employees
- merge learning year and rule management into a single module
- fix loading of saved plans by parsing dates
- extend data types with rule assignments

## Testing
- `npx biome lint --write`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68400e629400832081f763874f170e8c