### PR TITLE
Add simple local user auth

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
+import { AuthProvider } from "@/hooks/use-auth";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -18,7 +19,7 @@ export default function RootLayout({
   return (
     <html lang="de">
       <body className={`${inter.className} antialiased`}>
-        {children}
+        <AuthProvider>{children}</AuthProvider>
         <Toaster />
       </body>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,9 @@
+'use client';
 import { SchichtplanerApp } from '@/components/SchichtplanerApp';
+import { UserAuth } from '@/components/UserAuth';
+import { useAuth } from '@/hooks/use-auth';
 
 export default function Page() {
-  return <SchichtplanerApp />;
+  const { user } = useAuth();
+  return user ? <SchichtplanerApp /> : <UserAuth />;
 }

--- a/src/components/SchichtplanerApp.tsx
+++ b/src/components/SchichtplanerApp.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useAuth } from '@/hooks/use-auth';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -16,29 +16,8 @@ import { useToast } from '@/hooks/use-toast';
 import { exportAllData, importAllData } from '@/lib/dataManager';
 
 export function SchichtplanerApp() {
-  const [userId, setUserId] = useState<string>('demo-user-001');
+  const { user, logout } = useAuth();
   const { toast } = useToast();
-
-  useEffect(() => {
-    // Simulate user authentication
-    const generateUserId = () => {
-      const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-      let result = '';
-      for (let i = 0; i < 22; i++) {
-        result += chars.charAt(Math.floor(Math.random() * chars.length));
-      }
-      return result;
-    };
-
-    const storedUserId = localStorage.getItem('schichtplaner-user-id');
-    if (storedUserId) {
-      setUserId(storedUserId);
-    } else {
-      const newUserId = generateUserId();
-      localStorage.setItem('schichtplaner-user-id', newUserId);
-      setUserId(newUserId);
-    }
-  }, []);
 
   const handleExportAll = () => {
     try {
@@ -90,7 +69,7 @@ export function SchichtplanerApp() {
             <div className="flex justify-between items-center">
               <div>
                 <h1 className="text-3xl font-bold">Schichtplaner</h1>
-                <p className="text-slate-300 text-sm">UserID: {userId}</p>
+                <p className="text-slate-300 text-sm">Angemeldet als: {user?.username}</p>
               </div>
               <div className="flex space-x-2">
                 <input
@@ -117,6 +96,9 @@ export function SchichtplanerApp() {
                 >
                   <Download className="w-4 h-4 mr-2" />
                   Globaler Export (JSON)
+                </Button>
+                <Button variant="ghost" size="sm" onClick={logout}>
+                  Logout
                 </Button>
               </div>
             </div>

--- a/src/components/UserAuth.tsx
+++ b/src/components/UserAuth.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useAuth } from '@/hooks/use-auth';
+import { useToast } from '@/hooks/use-toast';
+
+export function UserAuth() {
+  const { login, register } = useAuth();
+  const { toast } = useToast();
+  const [mode, setMode] = useState<'login' | 'register'>('login');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = () => {
+    const action = mode === 'login' ? login : register;
+    const result = action(username, password);
+    if (!result.success) {
+      toast({ title: result.message || 'Fehler', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-50 p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>
+            {mode === 'login' ? 'Anmelden' : 'Registrieren'}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="username">Benutzername</Label>
+            <Input
+              id="username"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">Passwort</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+            />
+          </div>
+          <Button className="w-full" onClick={handleSubmit}>
+            {mode === 'login' ? 'Einloggen' : 'Registrieren'}
+          </Button>
+          <Button
+            variant="ghost"
+            className="w-full"
+            onClick={() => setMode(mode === 'login' ? 'register' : 'login')}
+          >
+            {mode === 'login'
+              ? 'Noch keinen Account? Registrieren'
+              : 'Bereits registriert? Anmelden'}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState, useEffect, createContext, useContext } from 'react';
+import type { User } from '@/lib/types';
+import {
+  saveUser,
+  authenticateUser,
+  setCurrentUser,
+  getCurrentUser,
+  findUserByUsername,
+} from '@/lib/dataManager';
+
+interface AuthContextType {
+  user: User | null;
+  register: (username: string, password: string) => { success: boolean; message?: string };
+  login: (username: string, password: string) => { success: boolean; message?: string };
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const current = getCurrentUser();
+    setUser(current);
+  }, []);
+
+  const register = (username: string, password: string) => {
+    if (findUserByUsername(username)) {
+      return { success: false, message: 'Benutzername bereits vergeben' };
+    }
+    const newUser = saveUser({ username, password });
+    setCurrentUser(newUser.id);
+    setUser(newUser);
+    return { success: true };
+  };
+
+  const login = (username: string, password: string) => {
+    const existing = authenticateUser(username, password);
+    if (!existing) return { success: false, message: 'Ungültige Anmeldedaten' };
+    setCurrentUser(existing.id);
+    setUser(existing);
+    return { success: true };
+  };
+
+  const logout = () => {
+    setCurrentUser(null);
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, register, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -97,6 +97,14 @@ export interface Absence {
   updatedAt: Date;
 }
 
+export interface User {
+  id: string;
+  username: string;
+  password: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export interface DayShiftNeed {
   shiftTypeId: string;
   count: number;


### PR DESCRIPTION
## Summary
- add `User` type and user management helpers in `dataManager`
- provide `AuthProvider` and `useAuth` hook
- add `UserAuth` component for login/registration
- show login or main app in `Page` based on auth state
- display logged in user and logout option in header

## Testing
- `npm run lint` *(fails: bunx not found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68413824eaa48320809550ac0131d7dd