### PR TITLE
Add constant for FTE hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,6 @@ Teams can define an `overallShiftPercentage` to express what portion of all
 support shifts a team should cover. During scheduling, the algorithm prioritizes
 teams that are below their target share, distributing remaining shifts fairly
 between employees within each team.
+
+The system assumes a full-time workload is **42.5 hours per week**, which is
+used when calculating utilization statistics.

--- a/src/components/AnalyticsDashboard.tsx
+++ b/src/components/AnalyticsDashboard.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Users, Clock, AlertTriangle, TrendingUp, Calendar, BarChart3 } from 'lucide-react';
+import { FULL_TIME_WEEKLY_HOURS } from '@/lib/constants';
 import type { Employee, Team, ShiftType, ShiftAssignment, WorkloadStats } from '@/lib/types';
 
 interface AnalyticsDashboardProps {
@@ -97,7 +98,8 @@ export function AnalyticsDashboard({
       };
 
       const team = teams.find(t => t.id === employee.teamId);
-      const expectedHours = (stats.targetPercentage / 100) * 40 * getPeriodLength(); // Assuming 40h full-time week
+      const expectedHours =
+        (stats.targetPercentage / 100) * FULL_TIME_WEEKLY_HOURS * getPeriodLength();
       const utilizationPercentage = expectedHours > 0 ? (stats.hours / expectedHours) * 100 : 0;
 
       const isOverworked = utilizationPercentage > 110;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const FULL_TIME_WEEKLY_HOURS = 42.5;

--- a/src/lib/reportGenerator.ts
+++ b/src/lib/reportGenerator.ts
@@ -4,6 +4,7 @@ import type { HAlignType } from 'jspdf-autotable';
 import { format, isWeekend, startOfWeek, endOfWeek, eachDayOfInterval } from 'date-fns';
 import { de } from 'date-fns/locale';
 import type { Employee, Team, ShiftType, ShiftAssignment, WorkloadStats } from './types';
+import { FULL_TIME_WEEKLY_HOURS } from './constants';
 
 interface JsPDFWithPlugin extends jsPDF {
   lastAutoTable?: {
@@ -116,7 +117,8 @@ export class ReportGenerator {
       };
 
       const team = this.options.teams.find(t => t.id === employee.teamId);
-      const expectedHours = (stats.targetPercentage / 100) * 40 * 4; // 4 weeks
+      const expectedHours =
+        (stats.targetPercentage / 100) * FULL_TIME_WEEKLY_HOURS * 4;
       const utilizationPercentage = expectedHours > 0 ? (stats.hours / expectedHours) * 100 : 0;
       const daysWorked = Object.keys(stats.daysWorkedThisPeriod).length;
 


### PR DESCRIPTION
## Summary
- add `FULL_TIME_WEEKLY_HOURS` constant
- use the new constant when computing expected hours
- document default 42.5 h full‑time week

## Testing
- `npm run lint` *(fails: bunx not found / existing lint errors)*
- `bunx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684147c4ff748320bcf86f80100cfde3