### PR TITLE
Fix team target calc in shift scheduler

### DIFF
--- a/src/lib/shiftScheduler.ts
+++ b/src/lib/shiftScheduler.ts
@@ -103,14 +103,19 @@ export class ShiftScheduler {
     const current = new Date(this.options.startDate);
     const end = new Date(this.options.endDate);
     while (current <= end) {
-      if (this.getWeekdayName(current)) {
-        totalSlots += this.options.shiftTypes.length;
+      const weekday = this.getWeekdayName(current);
+      if (weekday) {
+        for (const st of this.options.shiftTypes) {
+          totalSlots += st.weeklyNeeds[weekday] ?? 0;
+        }
       }
       current.setDate(current.getDate() + 1);
     }
 
     for (const team of this.options.teams) {
-      this.teamTargets[team.id] = Math.round((team.overallShiftPercentage / 100) * totalSlots);
+      this.teamTargets[team.id] = Math.round(
+        (team.overallShiftPercentage / 100) * totalSlots,
+      );
       this.teamWorkloads[team.id] = 0;
     }
   }


### PR DESCRIPTION
## Summary
- fix logic for calculating team targets to respect per-day shift needs

## Testing
- `bun x biome lint --write`
- `bun x tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684153e5b1bc8320a18af08bcbf872cc