### PR TITLE
Fix duplicate conflict entries

### DIFF
--- a/src/components/AnalyticsDashboard.tsx
+++ b/src/components/AnalyticsDashboard.tsx
@@ -336,8 +336,8 @@ export function AnalyticsDashboard({
           </CardHeader>
           <CardContent>
             <div className="space-y-2 max-h-60 overflow-y-auto">
-              {conflicts.map(conflict => (
-                <div key={conflict} className="bg-red-50 border border-red-200 rounded p-2">
+              {conflicts.map((conflict, index) => (
+                <div key={`${index}-${conflict}`} className="bg-red-50 border border-red-200 rounded p-2">
                   <div className="text-sm text-red-700">{conflict}</div>
                 </div>
               ))}

--- a/src/lib/shiftScheduler.ts
+++ b/src/lib/shiftScheduler.ts
@@ -737,10 +737,10 @@ export class ShiftScheduler {
 
     return {
       assignments: this.assignments,
-      conflicts: this.conflicts,
+      conflicts: Array.from(new Set(this.conflicts)),
       statistics: {
         totalAssignments: this.assignments.length,
-        unassignedShifts: this.conflicts.length,
+        unassignedShifts: Array.from(new Set(this.conflicts)).length,
         employeeWorkloads: this.employeeWorkloads,
         teamWorkloads: this.teamWorkloads,
       },


### PR DESCRIPTION
## Summary
- remove duplicate conflict messages when generating schedule
- ensure conflict items in the dashboard have unique keys

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841686338888320ba55be2897eed6c2