### PR TITLE
Fix scheduler counting of follow-up shifts

### DIFF
--- a/src/lib/shiftScheduler.ts
+++ b/src/lib/shiftScheduler.ts
@@ -659,7 +659,10 @@ export class ShiftScheduler {
           for (const shiftType of group) {
             const need = shiftType.weeklyNeeds[weekday] ?? 0;
             let assignedCount = this.assignments.filter(
-              (a) => a.date === dateStr && a.shiftId === shiftType.id,
+              (a) =>
+                a.date === dateStr &&
+                a.shiftId === shiftType.id &&
+                !a.isFollowUp,
             ).length;
             while (assignedCount < need) {
               let employee: Employee | null = null;


### PR DESCRIPTION
## Summary
- ensure mandatory follow-up assignments don't satisfy regular shift needs

## Testing
- `npx tsc --noEmit` *(fails: Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_68416ed303088320b18366acea65fbeb