### PR TITLE
Fix follow-up shift over-assignment

### DIFF
--- a/src/lib/shiftScheduler.ts
+++ b/src/lib/shiftScheduler.ts
@@ -372,6 +372,15 @@ export class ShiftScheduler {
       if (alreadyPrimary || alreadyThisShift) {
         return false;
       }
+
+      const weekday = this.getWeekdayName(followDate);
+      const demand = weekday ? toShift.weeklyNeeds[weekday] ?? 0 : 0;
+      const currentCount = this.assignments.filter(
+        (a) => a.date === followDateStr && a.shiftId === toShift.id,
+      ).length;
+      if (currentCount >= demand) {
+        return false;
+      }
     }
     return true;
   }
@@ -432,6 +441,15 @@ export class ShiftScheduler {
           a.shiftId === toShift.id,
       );
       if (alreadyPrimary || alreadyThisShift) {
+        continue;
+      }
+
+      const weekday = this.getWeekdayName(followDate);
+      const demand = weekday ? toShift.weeklyNeeds[weekday] ?? 0 : 0;
+      const currentCount = this.assignments.filter(
+        (a) => a.date === followDateStr && a.shiftId === toShift.id,
+      ).length;
+      if (currentCount >= demand) {
         continue;
       }
 
@@ -659,10 +677,7 @@ export class ShiftScheduler {
           for (const shiftType of group) {
             const need = shiftType.weeklyNeeds[weekday] ?? 0;
             let assignedCount = this.assignments.filter(
-              (a) =>
-                a.date === dateStr &&
-                a.shiftId === shiftType.id &&
-                !a.isFollowUp,
+              (a) => a.date === dateStr && a.shiftId === shiftType.id,
             ).length;
             while (assignedCount < need) {
               let employee: Employee | null = null;


### PR DESCRIPTION
## Summary
- enforce demand check when applying mandatory follow-ups
- include follow-up assignments when calculating the number of filled shift slots

## Testing
- `bun x biome lint --write`
- `bun x tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684170f64fd88320868c7aedee701d1f