### PR TITLE
Fix 0./1. VM double booking

### DIFF
--- a/src/lib/shiftScheduler.ts
+++ b/src/lib/shiftScheduler.ts
@@ -500,13 +500,17 @@ export class ShiftScheduler {
   ): boolean {
     if (!employee.allowedShifts.includes(shiftType.id)) return false;
     if (!this.isEmployeeAvailable(employee, date, shiftType)) return false;
-    if (
-      this.assignments.some(
-        (a) =>
-          a.employeeId === employee.id && a.date === dateStr && !a.isFollowUp,
-      )
-    )
-      return false;
+    const existing = this.assignments.find(
+      (a) => a.employeeId === employee.id && a.date === dateStr && !a.isFollowUp,
+    );
+    if (existing) {
+      const pairAllowed =
+        (existing.shiftId === this.zeroShiftId &&
+          shiftType.id === this.firstVmShiftId) ||
+        (existing.shiftId === this.firstVmShiftId &&
+          shiftType.id === this.zeroShiftId);
+      if (!pairAllowed) return false;
+    }
     if (this.violatesForbiddenSequence(employee, date, shiftType)) return false;
     if (!this.canApplyMandatoryFollowUps(employee, date, shiftType))
       return false;


### PR DESCRIPTION
## Summary
- allow employees already booked on 0. or 1. VM to also take the counterpart shift

## Testing
- `bun x biome lint --write`
- `bun x tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68417b089aa08320a8eda2e6ea9b268a