### PR TITLE
Rename shift fields and improve planner

### DIFF
--- a/src/components/ShiftCalendarGrid.tsx
+++ b/src/components/ShiftCalendarGrid.tsx
@@ -182,7 +182,7 @@ export function ShiftCalendarGrid({
       if (
         !emp ||
         !shift ||
-        !emp.allowedShifts.includes(shift.id) ||
+        !emp.Shiftsallowed[shift.id] ||
         !isAvailable(emp, new Date(editingCell.date), shift)
       ) {
         toast({
@@ -239,7 +239,7 @@ export function ShiftCalendarGrid({
     const d = new Date(date);
 
     return employees.filter((employee) => {
-      if (!employee.allowedShifts.includes(shiftTypeId)) return false;
+      if (!employee.Shiftsallowed[shiftTypeId]) return false;
 
       if (!isAvailable(employee, d, shiftType)) return false;
 
@@ -313,14 +313,19 @@ export function ShiftCalendarGrid({
                         const assignment = getAssignment(dateStr, shiftType.id);
                         const employee = assignment ? getEmployee(assignment.employeeId) : undefined;
                         const isConflict = hasConflict(dateStr, shiftType.id);
+                        const weekday = getWeekdayName(date);
+                        const demand = weekday ? shiftType.weeklyNeeds[weekday] ?? 0 : 0;
+                        const disabled = demand === 0;
 
                         return (
                           <td
                             key={date.toISOString()}
-                            className={`border p-1 text-center cursor-pointer hover:bg-gray-50 transition-colors ${
-                              isConflict ? 'bg-red-50' : ''
-                            }`}
-                            onClick={() => handleCellClick(dateStr, shiftType.id)}
+                            className={`border p-1 text-center ${
+                              disabled ? 'bg-gray-100 text-gray-400' : 'cursor-pointer hover:bg-gray-50'
+                            } ${isConflict ? 'bg-red-50' : ''}`}
+                            onClick={() => {
+                              if (!disabled) handleCellClick(dateStr, shiftType.id);
+                            }}
                           >
                             {employee ? (
                               <div className="space-y-1">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,1 +1,5 @@
 export const FULL_TIME_WEEKLY_HOURS = 42.5;
+// Total hours required by all shifts per week
+export const TOTAL_WEEKLY_SHIFT_HOURS = 215.5;
+// Total hours for a standard 4 week planning period
+export const TOTAL_FOUR_WEEK_SHIFT_HOURS = 862;

--- a/src/lib/csvUtils.ts
+++ b/src/lib/csvUtils.ts
@@ -59,8 +59,8 @@ export function employeesToCSV(employees: Employee[]): string {
     "grade",
     "teamId",
     "specificShiftPercentage",
-    "allowedShifts",
-    "shiftSuitability",
+    "Shiftsallowed",
+    "ShiftsSuitability",
     "availability",
     "createdAt",
     "updatedAt",
@@ -79,8 +79,8 @@ export function employeesToCSV(employees: Employee[]): string {
       employee.grade,
       employee.teamId,
       employee.specificShiftPercentage ?? "",
-      JSON.stringify(employee.allowedShifts),
-      JSON.stringify(employee.shiftSuitability ?? {}),
+      JSON.stringify(employee.Shiftsallowed),
+      JSON.stringify(employee.ShiftsSuitability),
       JSON.stringify(employee.availability),
       employee.createdAt.toISOString(),
       employee.updatedAt.toISOString(),
@@ -129,20 +129,19 @@ export function csvToEmployees(
                 ? 100
                 : undefined;
           break;
-        case "allowedShifts":
-        case "shiftSuitability":
+        case "Shiftsallowed":
+        case "ShiftsSuitability":
         case "availability":
           try {
             employee[header] = value
               ? JSON.parse(value)
-              : header === "allowedShifts"
-                ? []
-                : header === "shiftSuitability"
+              : header === "Shiftsallowed"
+                ? {}
+                : header === "ShiftsSuitability"
                   ? {}
                 : {};
           } catch {
-            employee[header] = header === "allowedShifts" ? [] : {};
-            if (header === "shiftSuitability") employee[header] = {};
+            employee[header] = {};
           }
           break;
       }

--- a/src/lib/shiftScheduler.ts
+++ b/src/lib/shiftScheduler.ts
@@ -344,7 +344,7 @@ export class ShiftScheduler {
       if (!rule.sameDay) followDate.setDate(followDate.getDate() + 1);
       const followDateStr = followDate.toISOString().split("T")[0];
 
-      if (!employee.allowedShifts.includes(toShift.id)) {
+      if (!employee.Shiftsallowed[toShift.id]) {
         this.conflicts.push(
           `Folgeschicht ${toShift.name} für ${employee.firstName} ${employee.lastName} am ${followDateStr} nicht erlaubt`,
         );
@@ -415,7 +415,7 @@ export class ShiftScheduler {
       if (!rule.sameDay) followDate.setDate(followDate.getDate() + 1);
       const followDateStr = followDate.toISOString().split("T")[0];
 
-      if (!employee.allowedShifts.includes(toShift.id)) {
+      if (!employee.Shiftsallowed[toShift.id]) {
         this.conflicts.push(
           `Folgeschicht ${toShift.name} für ${employee.firstName} ${employee.lastName} am ${followDateStr} nicht erlaubt`,
         );
@@ -498,7 +498,7 @@ export class ShiftScheduler {
     shiftType: ShiftType,
     dateStr: string,
   ): boolean {
-    if (!employee.allowedShifts.includes(shiftType.id)) return false;
+    if (!employee.Shiftsallowed[shiftType.id]) return false;
     if (!this.isEmployeeAvailable(employee, date, shiftType)) return false;
     const existing = this.assignments.find(
       (a) => a.employeeId === employee.id && a.date === dateStr && !a.isFollowUp,
@@ -567,8 +567,8 @@ export class ShiftScheduler {
       const loadDiff =
         this.employeeWorkloads[a.id].hours - this.employeeWorkloads[b.id].hours;
       if (loadDiff !== 0) return loadDiff;
-      const suitA = a.shiftSuitability?.[shiftType.id] ?? 0;
-      const suitB = b.shiftSuitability?.[shiftType.id] ?? 0;
+      const suitA = a.ShiftsSuitability?.[shiftType.id] ?? 0;
+      const suitB = b.ShiftsSuitability?.[shiftType.id] ?? 0;
       return suitB - suitA;
     });
 
@@ -610,7 +610,7 @@ export class ShiftScheduler {
     dateStr: string,
   ): Employee | null {
     for (const emp of this.options.employees) {
-      if (!emp.allowedShifts.includes(shiftType.id)) continue;
+      if (!emp.Shiftsallowed[shiftType.id]) continue;
       if (!this.isEmployeeAvailable(emp, date, shiftType)) continue;
       if (
         this.assignments.some(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,15 +8,15 @@ export interface Employee {
   grade: number; // Percentage (1-100)
   teamId: string;
   specificShiftPercentage?: number; // Optional override for team percentage
-  allowedShifts: string[]; // Array of shift type IDs
+  Shiftsallowed: Record<string, boolean>; // Keyed by shift type ID
   /** IDs of Schichtregeln, die speziell für diesen Mitarbeiter gelten */
-  ruleIds?: string[];
+  ruleIds: Record<string, boolean>;
   /**
    * Optional rating of how suitable an employee is for a given shift type.
    * The key is the shift type id and the value is a number from 0-5 where 5
    * means highly suitable and 0 means not suitable.
    */
-  shiftSuitability?: Record<string, number>;
+  ShiftsSuitability: Record<string, number>;
   availability: Record<string, boolean>; // e.g. {"monday_AM": true, "monday_PM": false}
   createdAt: Date;
   updatedAt: Date;
@@ -28,7 +28,7 @@ export interface Team {
   overallShiftPercentage: number; // Percentage (0-100)
   teamLeaderId?: string; // Optional employee ID of team leader
   /** IDs of Schichtregeln, die für dieses Team gelten */
-  ruleIds?: string[];
+  ruleIds: Record<string, boolean>;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## Summary
- rename `allowedShifts` to `Shiftsallowed`
- rename `shiftSuitability` to `ShiftsSuitability`
- change rule IDs to map of booleans
- add constants for weekly and four-week shift hours
- disable planner cells without demand

## Testing
- `npm run lint` *(fails: bunx not found earlier, then TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684201aac16083209260961a85753ad5