### PR TITLE
Implement dynamic hour calculations

### DIFF
--- a/src/components/AnalyticsDashboard.tsx
+++ b/src/components/AnalyticsDashboard.tsx
@@ -6,6 +6,7 @@ import { Progress } from '@/components/ui/progress';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Users, Clock, AlertTriangle, TrendingUp, Calendar, BarChart3 } from 'lucide-react';
 import { FULL_TIME_WEEKLY_HOURS } from '@/lib/constants';
+import { calculateShiftDuration } from '@/lib/constants';
 import type { Employee, Team, ShiftType, ShiftAssignment, WorkloadStats } from '@/lib/types';
 
 interface AnalyticsDashboardProps {
@@ -43,6 +44,21 @@ export function AnalyticsDashboard({
       0,
     );
     return Number(total.toFixed(1));
+  };
+
+  // Calculate required working hours for the period based on shift definitions
+  const calculateRequiredHours = () => {
+    const weeks = getPeriodLength();
+    let hours = 0;
+    for (const st of shiftTypes) {
+      const duration = calculateShiftDuration(st);
+      const weeklyNeed = Object.values(st.weeklyNeeds).reduce(
+        (sum, need) => sum + need,
+        0,
+      );
+      hours += duration * weeklyNeed * weeks;
+    }
+    return Number(hours.toFixed(1));
   };
 
   // Calculate shift coverage statistics
@@ -168,7 +184,9 @@ export function AnalyticsDashboard({
             <Clock className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{calculateTotalHours()}</div>
+            <div className="text-2xl font-bold">
+              {calculateTotalHours()} / {calculateRequiredHours()} h
+            </div>
             <p className="text-xs text-muted-foreground">
               Über {periodWeeks} Wochen
             </p>

--- a/src/components/EmployeeManagement.tsx
+++ b/src/components/EmployeeManagement.tsx
@@ -276,6 +276,19 @@ export function EmployeeManagement() {
     }));
   };
 
+  const handleTeamChange = (teamId: string) => {
+    const team = teams.find(t => t.id === teamId);
+    const defaultRules = shiftRules.reduce<Record<string, boolean>>((acc, r) => {
+      acc[r.id] = team?.ruleIds?.[r.id] ?? false;
+      return acc;
+    }, {});
+    setFormData(prev => ({
+      ...prev,
+      teamId,
+      ruleIds: defaultRules,
+    }));
+  };
+
 
   const getTeamName = (teamId: string) => {
     const team = teams.find(t => t.id === teamId);
@@ -473,7 +486,7 @@ export function EmployeeManagement() {
                   <Label htmlFor="teamId">Team *</Label>
                   <Select
                     value={formData.teamId}
-                    onValueChange={(value) => setFormData(prev => ({ ...prev, teamId: value }))}
+                    onValueChange={(value) => handleTeamChange(value)}
                   >
                     <SelectTrigger>
                       <SelectValue placeholder="Team wählen" />

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,40 @@
+import type { ShiftType } from './types';
+import { WEEKDAYS } from './types';
+
 export const FULL_TIME_WEEKLY_HOURS = 42.5;
-// Total hours required by all shifts per week
-export const TOTAL_WEEKLY_SHIFT_HOURS = 215.5;
-// Total hours for a standard 4 week planning period
-export const TOTAL_FOUR_WEEK_SHIFT_HOURS = 862;
+
+/**
+ * Calculate the duration of a single shift in hours.
+ */
+export function calculateShiftDuration(shift: ShiftType): number {
+  const [startH, startM] = shift.startTime.split(':').map(Number);
+  const [endH, endM] = shift.endTime.split(':').map(Number);
+
+  const startMinutes = startH * 60 + startM;
+  let endMinutes = endH * 60 + endM;
+  if (endMinutes < startMinutes) {
+    endMinutes += 24 * 60; // overnight shift
+  }
+  return (endMinutes - startMinutes) / 60;
+}
+
+/**
+ * Sum up the required hours for all shift types for a single week.
+ */
+export function calculateWeeklyShiftHours(shiftTypes: ShiftType[]): number {
+  let hours = 0;
+  for (const st of shiftTypes) {
+    const duration = calculateShiftDuration(st);
+    for (const day of WEEKDAYS) {
+      hours += (st.weeklyNeeds[day] ?? 0) * duration;
+    }
+  }
+  return hours;
+}
+
+/**
+ * Get the required hours for a standard four week planning period.
+ */
+export function calculateFourWeekShiftHours(shiftTypes: ShiftType[]): number {
+  return calculateWeeklyShiftHours(shiftTypes) * 4;
+}

--- a/src/lib/csvUtils.ts
+++ b/src/lib/csvUtils.ts
@@ -62,6 +62,7 @@ export function employeesToCSV(employees: Employee[]): string {
     "Shiftsallowed",
     "ShiftsSuitability",
     "availability",
+    "ruleIds",
     "createdAt",
     "updatedAt",
   ];
@@ -82,6 +83,7 @@ export function employeesToCSV(employees: Employee[]): string {
       JSON.stringify(employee.Shiftsallowed),
       JSON.stringify(employee.ShiftsSuitability),
       JSON.stringify(employee.availability),
+      JSON.stringify(employee.ruleIds),
       employee.createdAt.toISOString(),
       employee.updatedAt.toISOString(),
     ];
@@ -132,6 +134,7 @@ export function csvToEmployees(
         case "Shiftsallowed":
         case "ShiftsSuitability":
         case "availability":
+        case "ruleIds":
           try {
             employee[header] = value
               ? JSON.parse(value)
@@ -139,7 +142,9 @@ export function csvToEmployees(
                 ? {}
                 : header === "ShiftsSuitability"
                   ? {}
-                : {};
+                : header === "availability"
+                  ? {}
+                  : {};
           } catch {
             employee[header] = {};
           }
@@ -162,6 +167,7 @@ export function teamsToCSV(teams: Team[]): string {
     "name",
     "overallShiftPercentage",
     "teamLeaderId",
+    "ruleIds",
     "createdAt",
     "updatedAt",
   ];
@@ -174,6 +180,7 @@ export function teamsToCSV(teams: Team[]): string {
       team.name,
       team.overallShiftPercentage,
       team.teamLeaderId || "",
+      JSON.stringify(team.ruleIds || {}),
       team.createdAt.toISOString(),
       team.updatedAt.toISOString(),
     ];
@@ -211,6 +218,13 @@ export function csvToTeams(
           break;
         case "teamLeaderId":
           team[header] = value || undefined;
+          break;
+        case "ruleIds":
+          try {
+            team[header] = value ? JSON.parse(value) : {};
+          } catch {
+            team[header] = {};
+          }
           break;
       }
     }


### PR DESCRIPTION
## Summary
- calculate shift durations and required hours in constants
- show required hours on analytics dashboard
- sync employee rule flags with team selection
- include ruleIds in CSV import/export

## Testing
- `npm run lint` *(fails: bunx not found)*
- `npx tsc --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684210da0de48320b04cc64054b04b30