### PR TITLE
Fix shift defaults and rule inheritance

### DIFF
--- a/src/components/EmployeeManagement.tsx
+++ b/src/components/EmployeeManagement.tsx
@@ -252,7 +252,7 @@ export function EmployeeManagement() {
       Shiftsallowed: { ...prev.Shiftsallowed, [shiftTypeId]: checked },
       ShiftsSuitability: {
         ...prev.ShiftsSuitability,
-        [shiftTypeId]: checked ? prev.ShiftsSuitability[shiftTypeId] ?? 3 : 0,
+        [shiftTypeId]: checked ? prev.ShiftsSuitability[shiftTypeId] || 3 : 0,
       },
     }));
   };
@@ -263,14 +263,17 @@ export function EmployeeManagement() {
     setFormData(prev => ({
       ...prev,
       lehrjahr,
-      availability: qualification?.defaultAvailability || {},
+      availability: {
+        ...createDefaultAvailability(),
+        ...(qualification?.defaultAvailability || {}),
+      },
       Shiftsallowed: shiftTypes.reduce<Record<string, boolean>>((acc, st) => {
         acc[st.id] = qualification?.qualifiedShiftTypes.includes(st.id) ?? false;
         return acc;
       }, {}),
       ShiftsSuitability: shiftTypes.reduce<Record<string, number>>((acc, st) => {
         const allowed = qualification?.qualifiedShiftTypes.includes(st.id) ?? false;
-        acc[st.id] = allowed ? prev.ShiftsSuitability[st.id] ?? 3 : 0;
+        acc[st.id] = allowed ? prev.ShiftsSuitability[st.id] || 3 : 0;
         return acc;
       }, {}),
     }));

--- a/src/lib/shiftScheduler.ts
+++ b/src/lib/shiftScheduler.ts
@@ -284,6 +284,11 @@ export class ShiftScheduler {
     return Math.floor((d2.getTime() - d1.getTime()) / (24 * 60 * 60 * 1000));
   }
 
+  private doesRuleApply(employee: Employee, rule: ShiftRule): boolean {
+    const team = this.options.teams.find((t) => t.id === employee.teamId);
+    return Boolean(employee.ruleIds?.[rule.id] || team?.ruleIds?.[rule.id]);
+  }
+
   private violatesForbiddenSequence(
     employee: Employee,
     date: Date,
@@ -291,6 +296,7 @@ export class ShiftScheduler {
   ): boolean {
     for (const rule of this.options.shiftRules) {
       if (rule.type !== "forbidden_sequence") continue;
+      if (!this.doesRuleApply(employee, rule)) continue;
       const toIds = rule.toShiftIds || [];
 
       for (const a of this.assignments) {
@@ -325,6 +331,7 @@ export class ShiftScheduler {
         rule.fromShiftId !== shiftType.id
       )
         continue;
+      if (!this.doesRuleApply(employee, rule)) continue;
       const toShift = this.shiftMap[rule.toShiftId ?? ""];
       if (!toShift) continue;
 
@@ -396,6 +403,7 @@ export class ShiftScheduler {
         rule.fromShiftId !== shiftType.id
       )
         continue;
+      if (!this.doesRuleApply(employee, rule)) continue;
       const toShift = this.shiftMap[rule.toShiftId ?? ""];
       if (!toShift) continue;
 


### PR DESCRIPTION
## Summary
- default shift suitability now set to 3 when enabling a shift
- selecting a learning year sets full default availability and uses 3 as initial suitability
- scheduler now respects rules assigned to employee teams

## Testing
- `npx biome lint --write`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68421685631c83208cfc3114a09423c4