### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
 import { AuthProvider } from "@/hooks/use-auth";
+import { ThemeProvider } from "@/components/theme-provider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -19,8 +20,10 @@ export default function RootLayout({
   return (
     <html lang="de">
       <body className={`${inter.className} antialiased`}>
-        <AuthProvider>{children}</AuthProvider>
-        <Toaster />
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+          <AuthProvider>{children}</AuthProvider>
+          <Toaster />
+        </ThemeProvider>
       </body>
 
     </html>

--- a/src/components/AbsenceCalendar.tsx
+++ b/src/components/AbsenceCalendar.tsx
@@ -117,13 +117,13 @@ export function AbsenceCalendar({ employees, absences, onRangeSelect, onAbsenceC
         <table className="w-full border-collapse">
           <thead>
             <tr>
-              <th className="border p-2 bg-gray-50 text-left font-medium min-w-[120px]">
+              <th className="border p-2 bg-secondary text-left font-medium min-w-[120px]">
                 Mitarbeiter
               </th>
               {daysArray.map((d) => (
                 <th
                   key={d.toISOString()}
-                  className="border p-1 bg-gray-50 text-center text-xs min-w-[40px]"
+                  className="border p-1 bg-secondary text-center text-xs min-w-[40px]"
                 >
                   {d.getDate()}
                 </th>
@@ -133,7 +133,7 @@ export function AbsenceCalendar({ employees, absences, onRangeSelect, onAbsenceC
           <tbody>
             {employees.map((emp) => (
               <tr key={emp.id}>
-                <td className="border p-1 bg-gray-50 text-sm font-medium">
+                <td className="border p-1 bg-secondary text-sm font-medium">
                   {emp.firstName} {emp.lastName}
                 </td>
                 {daysArray.map((d) => {

--- a/src/components/SchichtplanerApp.tsx
+++ b/src/components/SchichtplanerApp.tsx
@@ -14,6 +14,7 @@ import { DataProvider } from './DataProvider';
 import { Download, Upload } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { exportAllData, importAllData } from '@/lib/dataManager';
+import { ThemeToggle } from './ThemeToggle';
 
 export function SchichtplanerApp() {
   const { user, logout } = useAuth();
@@ -63,15 +64,16 @@ export function SchichtplanerApp() {
 
   return (
     <DataProvider>
-      <div className="min-h-screen bg-gray-50">
-        <header className="bg-slate-800 text-white shadow-lg">
+      <div className="min-h-screen bg-background">
+        <header className="bg-secondary text-secondary-foreground shadow-lg">
           <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
             <div className="flex justify-between items-center">
               <div>
                 <h1 className="text-3xl font-bold">Schichtplaner</h1>
-                <p className="text-slate-300 text-sm">Angemeldet als: {user?.username}</p>
+                <p className="text-muted-foreground text-sm">Angemeldet als: {user?.username}</p>
               </div>
-              <div className="flex space-x-2">
+              <div className="flex space-x-2 items-center">
+                <ThemeToggle />
                 <input
                   type="file"
                   accept=".json"
@@ -82,7 +84,6 @@ export function SchichtplanerApp() {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="text-slate-800 border-slate-300 bg-white hover:bg-slate-100"
                   onClick={() => document.getElementById('import-file')?.click()}
                 >
                   <Upload className="w-4 h-4 mr-2" />
@@ -91,7 +92,6 @@ export function SchichtplanerApp() {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="text-slate-800 border-slate-300 bg-white hover:bg-slate-100"
                   onClick={handleExportAll}
                 >
                   <Download className="w-4 h-4 mr-2" />

--- a/src/components/ShiftCalendarGrid.tsx
+++ b/src/components/ShiftCalendarGrid.tsx
@@ -281,11 +281,11 @@ export function ShiftCalendarGrid({
               <table className="w-full border-collapse">
                 <thead>
                   <tr>
-                    <th className="border p-2 bg-gray-50 text-left font-medium min-w-[120px]">
+                    <th className="border p-2 bg-secondary text-left font-medium min-w-[120px]">
                       Schicht
                     </th>
                     {week.map((date, dayIndex) => (
-                      <th key={date.toISOString()} className="border p-2 bg-gray-50 text-center font-medium min-w-[100px]">
+                      <th key={date.toISOString()} className="border p-2 bg-secondary text-center font-medium min-w-[100px]">
                         <div className="text-xs text-gray-600">
                           {Object.values(WEEKDAYS_SHORT)[dayIndex]}
                         </div>
@@ -302,7 +302,7 @@ export function ShiftCalendarGrid({
                 <tbody>
                   {orderedShiftTypes.map(shiftType => (
                     <tr key={shiftType.id}>
-                      <td className="border p-2 bg-gray-50 font-medium">
+                      <td className="border p-2 bg-secondary font-medium">
                         <div className="text-sm">{shiftType.name}</div>
                         <div className="text-xs text-gray-500">
                           {shiftType.startTime} - {shiftType.endTime}
@@ -321,7 +321,7 @@ export function ShiftCalendarGrid({
                           <td
                             key={date.toISOString()}
                             className={`border p-1 text-center ${
-                              disabled ? 'bg-gray-100 text-gray-400' : 'cursor-pointer hover:bg-gray-50'
+                              disabled ? 'bg-muted text-muted-foreground' : 'cursor-pointer hover:bg-secondary'
                             } ${isConflict ? 'bg-red-50' : ''}`}
                             onClick={() => {
                               if (!disabled) handleCellClick(dateStr, shiftType.id);

--- a/src/components/ShiftPlanner.tsx
+++ b/src/components/ShiftPlanner.tsx
@@ -308,7 +308,7 @@ export function ShiftPlanner() {
                 type="date"
                 value={endDate}
                 readOnly
-                className="bg-gray-100"
+                className="bg-muted"
               />
             </div>
             <div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Moon, Sun } from "lucide-react";
+
+export function ThemeToggle() {
+  const { theme, setTheme, systemTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  const current = theme === "system" ? systemTheme : theme;
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setTheme(current === "dark" ? "light" : "dark")}
+      aria-label="Toggle theme"
+    >
+      {current === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </Button>
+  );
+}

--- a/src/components/UserAuth.tsx
+++ b/src/components/UserAuth.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/hooks/use-toast';
+import { ThemeToggle } from './ThemeToggle';
 
 export function UserAuth() {
   const { login, register } = useAuth();
@@ -24,7 +25,10 @@ export function UserAuth() {
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-50 p-4">
+    <div className="relative flex items-center justify-center min-h-screen bg-background p-4">
+      <div className="absolute top-4 right-4">
+        <ThemeToggle />
+      </div>
       <Card className="w-full max-w-sm">
         <CardHeader>
           <CardTitle>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes/dist/types";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="light" enableSystem {...props}>
+      {children}
+    </NextThemesProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add ThemeProvider using `next-themes`
- create ThemeToggle component for switching between light and dark mode
- update layout to wrap app in ThemeProvider
- integrate dark-mode toggle into main app and login screen
- adjust components to use theme-aware classes

## Testing
- `bun x biome lint --write && bun x tsc --noEmit` *(fails: `bunx: command not found` / missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68503b8796748320b86b3de2dcb55afd